### PR TITLE
feat: Room Create API 수정

### DIFF
--- a/src/main/java/bc/bookchat/chat/presentation/ChatController.java
+++ b/src/main/java/bc/bookchat/chat/presentation/ChatController.java
@@ -19,7 +19,7 @@ public class ChatController {
     private final ChatService chatService;
     private final AuthService authService;
     // 채팅방 입장
-    @MessageMapping("chat/enter")
+    @MessageMapping("/chat/enter")
     public void enter(MessageRequestDto message, @Header("Authorization") String token) {
         log.info("user token: " + token);
         Member memberByJwt = authService.findMemberByJwt(token.substring(7));
@@ -35,7 +35,7 @@ public class ChatController {
     }
 
     // 채팅방 퇴장
-    @MessageMapping("chat/quit")
+    @MessageMapping("/chat/quit")
     public void quit(MessageRequestDto message, @Header("Authorization") String token) {
         log.info("user token: " + token);
         Member memberByJwt = authService.findMemberByJwt(token.substring(7));

--- a/src/main/java/bc/bookchat/room/service/RoomService.java
+++ b/src/main/java/bc/bookchat/room/service/RoomService.java
@@ -28,16 +28,19 @@ public class RoomService {
 
     @Transactional
     public RoomResponseDto createRoom(Long isbn) {
-        // DUPLICATE Room name
-        System.out.println("isbn : " + isbn);
-        if (roomRepository.findByRoomId(isbn).isPresent()) {
-            throw new CustomException(ErrorCode.DUPLICATE_RESOURCE);
-        }
         // IF BOOK NOT FIND, CREATE BOOK
         findBookOrCreate(isbn);
         MajorBook majorBook = bookService.findMajorBookByIsbn(isbn).orElseThrow();
-        Room room = Room.create(majorBook.getTitle(), isbn);
-        roomRepository.save(room);
+
+        // NOT DUPLICATE Room name -> room create(db에 저장)
+        // DUPLICATE -> 에러 대신 그냥 출력
+        System.out.println("isbn : " + isbn);
+        if (roomRepository.findByRoomId(isbn).isEmpty()) {
+            //throw new CustomException(ErrorCode.DUPLICATE_RESOURCE);
+            Room room = Room.create(majorBook.getTitle(), isbn);
+            roomRepository.save(room);
+        }
+
         return RoomResponseDto.toDto(isbn, majorBook.getTitle());
     }
 


### PR DESCRIPTION
채팅방이 이미 DB에 존재할 때 Duplicate Error 대신 Response 그대로 출력하도록 수정